### PR TITLE
Remove broken links to tidy3d-alpha doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,6 @@ This is the documentation for the python API, which is the main way to build sim
    howdoi
    api
    changelog
-   Old Documentation <https://simulation.cloud/docs/html/index.html>
 
 .. image:: _static/ring_resonator.png
    :width: 1200

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -7,7 +7,7 @@ Welcome to Tidy3d
 
 This page will get you set up with Tidy3D and running a simple example.
 
-.. note:: This is the documentation for the beta release of Tidy3D.  If you were interested in our previous version, it is documented `at this page <https://simulation.cloud/docs/html/index.html>`_. 
+.. note:: This is the documentation for the beta release of Tidy3D.
 
 Code Repositories
 -----------------


### PR DESCRIPTION
from two places:
- Start Here page (quickstart.rst)
- Index page and sidebar (index.rst)