### PR TITLE
Updated Docs

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -36,21 +36,21 @@ Case studies
 .. toctree::
     :maxdepth: 1
 
-    notebooks/RingResonator
-    notebooks/L3_cavity
-    notebooks/GratingCoupler
-    notebooks/GratingEfficiency
-    notebooks/Metalens
-    notebooks/MMI_1x4
-    notebooks/WaveguideCrossing
-    notebooks/HighQ_Si
-    notebooks/HighQ_Ge
-    notebooks/PolarizationSplitterRotator
     notebooks/Near2FarSphereRCS
-    notebooks/Adjoint
+    notebooks/PlasmonicNanoparticle.ipynb
+    notebooks/GratingEfficiency
     notebooks/BiosensorGrating.ipynb
     notebooks/BraggGratings.ipynb
-    notebooks/PlasmonicNanoparticle.ipynb
+    notebooks/HighQ_Si
+    notebooks/HighQ_Ge
     notebooks/DielectricMetasurfaceAbsorber.ipynb
+    notebooks/Metalens
     notebooks/Bandstructure.ipynb
+    notebooks/L3_cavity
     notebooks/YJunction.ipynb
+    notebooks/MMI_1x4
+    notebooks/WaveguideCrossing
+    notebooks/PolarizationSplitterRotator
+    notebooks/GratingCoupler
+    notebooks/RingResonator
+    notebooks/Adjoint

--- a/docs/source/notebooks/DielectricMetasurfaceAbsorber.ipynb
+++ b/docs/source/notebooks/DielectricMetasurfaceAbsorber.ipynb
@@ -82,7 +82,7 @@
    "id": "c889b550",
    "metadata": {},
    "source": [
-    "Two materials are involved in this model. The dielectric cylinder is made of silicon, which is described by a Drude model with $\\varepsilon_{\\inf}$=11.7 and plasma frequency $\\omega_P$=0.69 THz and damping rate $\\gamma$=0.83 THz. We can use the built-in [`Drude`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.Drude.html?highlight=drude) feature to describe the response of silicon. The thin substrate is made of PDMS, which has a relative permittivity of 1.72 and a loss tangent of 0.15 at the relevant frequency range. The relative permittivity and loss tangent will be converted to the complex refractive index then PDMS can be described by using the `from_nk` method of [`Medium`](https://docs.simulation.cloud/projects/tidy3d/en/latest/_autosummary/tidy3d.Medium.html)."
+    "Two materials are involved in this model. The dielectric cylinder is made of silicon, which is described by a Drude model with $\\varepsilon_{\\inf}$=11.7 and plasma frequency $\\omega_P$=0.69 THz and damping rate $\\gamma$=0.83 THz. We can use the built-in [Drude](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.Drude.html?highlight=drude) feature to describe the response of silicon. The thin substrate is made of PDMS, which has a relative permittivity of 1.72 and a loss tangent of 0.15 at the relevant frequency range. The relative permittivity and loss tangent will be converted to the complex refractive index then PDMS can be described by using the `from_nk` method of [Medium](https://docs.simulation.cloud/projects/tidy3d/en/latest/_autosummary/tidy3d.Medium.html)."
    ]
   },
   {
@@ -1198,7 +1198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/WaveguideCrossing.ipynb
+++ b/docs/source/notebooks/WaveguideCrossing.ipynb
@@ -55,7 +55,7 @@
    "id": "290a838f",
    "metadata": {},
    "source": [
-    "# Simulation Setup"
+    "## Simulation Setup"
    ]
   },
   {
@@ -697,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/YJunction.ipynb
+++ b/docs/source/notebooks/YJunction.ipynb
@@ -146,9 +146,9 @@
    "id": "98ae6d2c",
    "metadata": {},
    "source": [
-    "First, define the junction structure by using a [`PolySlab`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.PolySlab.html?highlight=polyslab). The vertices are given by the widths of the segments defined above. If a smooth curve is desirable, one can interpolate the vertices to a finer grid using spline for example. \n",
+    "First, define the junction structure by using a [PolySlab](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.PolySlab.html?highlight=polyslab). The vertices are given by the widths of the segments defined above. If a smooth curve is desirable, one can interpolate the vertices to a finer grid using spline for example. \n",
     "\n",
-    "Before proceeding further to construct other structures, we can use the [`plot`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.Structure.html) method to inspect the geometry. "
+    "Before proceeding further to construct other structures, we can use the [plot](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.Structure.html) method to inspect the geometry. "
    ]
   },
   {
@@ -297,9 +297,9 @@
    "id": "4eaa0e1e",
    "metadata": {},
    "source": [
-    "We will use a [`ModeSource`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.ModeSource.html?highlight=modesource) to excite the input waveguide using the fundamental TE mode. \n",
+    "We will use a [ModeSource](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.ModeSource.html?highlight=modesource) to excite the input waveguide using the fundamental TE mode. \n",
     "\n",
-    "A [`FluxMonitor`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.FluxMonitor.html) is placed at the top output waveguide to measure the transmission. Similarly, A [`ModeMonitor`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.ModeMonitor.html) is placed at the same location. Since we prefer not to excite higher order mode at the output waveguides, we need to perform mode decomposition to inspect the mode profile. Lastly, a [`FieldMonitor`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.FieldMonitor.html) is added to the xy plane to visualize the power flow."
+    "A [FluxMonitor](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.FluxMonitor.html) is placed at the top output waveguide to measure the transmission. Similarly, A [ModeMonitor](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.ModeMonitor.html) is placed at the same location. Since we prefer not to excite higher order mode at the output waveguides, we need to perform mode decomposition to inspect the mode profile. Lastly, a [FieldMonitor](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.FieldMonitor.html) is added to the xy plane to visualize the power flow."
    ]
   },
   {
@@ -389,7 +389,7 @@
    "id": "f7f50958",
    "metadata": {},
    "source": [
-    "Before submitting the simulation to the server, it is a good practice to visualize the mode profile at the `ModeSource` to ensure we are launching the fundamental TE mode. To do so, we will use the [`ModeSolver`](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.plugins.ModeSolver.html) plugin, which solves for the mode profile on your local computer."
+    "Before submitting the simulation to the server, it is a good practice to visualize the mode profile at the `ModeSource` to ensure we are launching the fundamental TE mode. To do so, we will use the [ModeSolver](https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.plugins.ModeSolver.html) plugin, which solves for the mode profile on your local computer."
    ]
   },
   {
@@ -916,7 +916,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -80,7 +80,7 @@ and the latest version of Tidy3D will be installed in this environment. To test 
 
     python -c "import tidy3d as td; print(td.__version__)"
 
-to confirm the installation is successful. If so, you should see the client version of Tidy3D being displayed. Now you can open your favorite Python IDE and start creating Tidy3D simulations!
+If the installation is successful, you should see the client version of Tidy3D being displayed. Now you can open your favorite Python IDE and start creating Tidy3D simulations!
 
 Additional Configuration for Python IDE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -39,24 +39,65 @@ Then the notebook will create a simulation and upload it to our server, where it
 
 To play around with the simulation parameters, you can edit the notebook directly and re-run.
 
-Python Installation
--------------------
+Installation of Tidy3D Python API
+---------------------------------
 
-If you have python set up on your computer and wish to run the python API locally, installation is simple.
+If you wish to run the Tidy3D Python API locally, follow the instructions below.
 
-Tidy3D and its dependencies can be installed from the command line by
+Create a new Python virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you already have Python installed on your computer, it is possible that some packages in your current environment could have version conflicts with Tidy3D. To avoid this, we strongly recommend that you create a clean Python virtual environment to install Tidy3D.
+
+We recommend using the Conda package management system to manage your Python virtual environment as well as installing Tidy3D. You can install Conda conveniently via `Anaconda <https://www.anaconda.com/>`__.
+
+After you install Anaconda, open the Anaconda Prompt and enter
 
 .. code-block:: bash
 
-    $ pip install tidy3d-beta
+    conda create –n tidy3d_env python==3.10
 
-To test whether the installation was successful you can run
+to create a new environment. ``tidy3d_env`` is the name for the new environment, which can be changed to your personal preference. Python version 3.10 and its associated packages will also be installed in this new environment by adding ``python==3.10``. After the environment is created, we need to activate it by
 
 .. code-block:: bash
 
-    $ python -c "import tidy3d as td; print(td.__version__)"
+    conda activate tidy3d_env
 
-or download and run an example script from `here <https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/readthedocs/docs/StartHere.py>`_.
+You are now ready to install Tidy3D in your new environment, which will be discussed in the next section. More information about Conda environment management tools can be found `here <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__.
+
+Install Tidy3D
+^^^^^^^^^^^^^^
+
+Tidy3D and its dependencies can be installed from the command line via ``pip``, which is installed with Python when the new environment is created. Simply run
+
+.. code-block:: bash
+
+    pip install tidy3d-beta
+
+and the latest version of Tidy3D will be installed in this environment. To test whether the installation was successful you can run
+
+.. code-block:: bash
+
+    python -c "import tidy3d as td; print(td.__version__)"
+
+to confirm the installation is successful. If so, you should see the client version of Tidy3D being displayed. Now you can open your favorite Python IDE and start creating Tidy3D simulations!
+
+Additional Configuration for Python IDE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your Python IDE of choice is not natively included in Anaconda, you need to configure the environment in your IDE manually. We will use the popular PyCharm IDE as an example. In PyCharm, go to File – Settings – Project – Python Interpreter. Click “Add Interpreter” and choose “Conda Environment”. Then click the “…” icon to choose the path for the Conda environment with Tidy3D installed. The path usually looks like
+
+``C:\Users\xxx\Anaconda3\envs\tidy3d_env\tidy3d_env\python.exe``.
+
+After clicking “OK”, your PyCharm project should be using the correct Conda environment. You can import Tidy3D using the usual
+
+.. code-block:: bash
+
+    import tidy3d as td
+
+in your codes.
+
+.. note:: Please pay attention to any warning or error messages during the installation process as your system configuration might be different. If you are experiencing difficulty in the installation, please reach out to us for help. We would gladly assist you for Tidy3D installation.
 
 Next Steps
 ==========


### PR DESCRIPTION
- A new installation instruction is added to the quickstart.rst; 

- Example notebooks are reordered in examples.rst so notebooks of similar category are listed together. For example, PIC examples, plasmonics examples, etc. I think it could make it easier for users to locate the examples they are looking for.

- Hyperlinks are fixed in metasurface and y junction notebooks; 

- Fixing one heading level in the waveguide crossing notebook.