### PR TITLE
Fixed header level

### DIFF
--- a/docs/source/notebooks/PlasmonicYagiUdaNanoantenna.ipynb
+++ b/docs/source/notebooks/PlasmonicYagiUdaNanoantenna.ipynb
@@ -1117,7 +1117,7 @@
    "id": "7a334ffc",
    "metadata": {},
    "source": [
-    "# Postprocessing"
+    "## Postprocessing"
    ]
   },
   {
@@ -2442,7 +2442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Just realized that on the website under '[Case studies](https://docs.flexcompute.com/projects/tidy3d/en/latest/examples.html#case-studies)', there is an entry called 'Postprocessing'. This is due to one header of the Plasmonic Yagi Uda antenna notebook being incorrect. It's fixed here so next time when the website is rebuilt, the issue should go away. 
