### PR TITLE
Use ssh in submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tidy3d"]
 	path = tidy3d
-	url = https://github.com/flexcompute/tidy3d.git
+	url = git@github.com:flexcompute/tidy3d.git


### PR DESCRIPTION
For some reason, I had [previously changed](https://github.com/flexcompute-readthedocs/tidy3d-docs/commit/ca436f59f32224614d01cb16a8f427e459373e2e) it (inadvertently) to use HTTPS, but when trying to configure git on my new computer could not push to the submodule without making it SSH.