### PR TITLE
Fixing typo

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -116,7 +116,7 @@ Photonic Integrated Circuit Components
     notebooks/EdgeCoupler
     notebooks/90OpticalHybrid
 
-Metamaterials, Grattings, and Other Periodic Structures
+Metamaterials, Gratings, and Other Periodic Structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
"Grating" was spelled incorrectly as "gratting". It's fixed here. 