### PR TITLE
Added a lectures section on the docs page

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,6 +1,15 @@
 Learning FDTD Through Examples
 ==============================
 
+Lecture Series
+--------------
+
+.. toctree::
+    :maxdepth: 1
+
+    fdtd101
+    inversedesign
+
 Examples of How to Use FDTD Features
 ------------------------------------
 

--- a/docs/source/fdtd101.rst
+++ b/docs/source/fdtd101.rst
@@ -1,0 +1,25 @@
+********
+FDTD 101
+********
+
+FDTD 101 is an introduction to the Finite-Difference Time-Domain Method for Electromagnetics. We will walk you through the basics of setting up and running electromagnetic simulations using the FDTD method. Through this course, you will gain a knowledge of the fundamental concepts behind electromagnetic simulation as well as many advanced topics worth considering when you set up your simulations.
+
+`Lecture 1: Introduction to FDTD Simulation <https://www.flexcompute.com/fdtd101/Lecture-1-Introduction-to-FDTD-Simulation/>`_
+
+`Lecture 2: Using FDTD to Compute a Transmission Spectrum <https://www.flexcompute.com/fdtd101/Lecture-2-Using-FDTD-to-Compute-a-Transmission-Spectrum/>`_
+
+`Lecture 3: Applying FDTD to Photonic Crystal Slab Simulation <https://www.flexcompute.com/fdtd101/Lecture-3-Applying-FDTD-to-Photonic-Crystal-Slab-Simulation/>`_
+
+`Lecture 4: Prelude to Integrated Photonics Simulation: Mode Injection <https://www.flexcompute.com/fdtd101/Lecture-4-Prelude-to-Integrated-Photonics-Simulation-Mode-Injection/>`_
+
+`Lecture 5: Modeling dispersive material in FDTD <https://www.flexcompute.com/fdtd101/Lecture-5-Modeling-dispersive-material-in-FDTD/>`_
+
+`Lecture 6: Introduction to perfectly matched layer (PML) <https://www.flexcompute.com/fdtd101/Lecture-6-Introduction-to-perfectly-matched-layer/>`_
+
+`Lecture 7: Time step size and CFL condition in FDTD <https://www.flexcompute.com/fdtd101/Lecture-7-Time-step-size-and-CFL-condition-in-FDTD/>`_
+
+`Lecture 8: Numerical dispersion in FDTD <https://www.flexcompute.com/fdtd101/Lecture-8-Numerical-dispersion-in-FDTD/>`_
+
+`Lecture 9: Dielectric constant assignment on Yee grids <https://www.flexcompute.com/fdtd101/Lecture-9-Dielectric-constant-assignment-on-Yee-grids/>`_
+
+`Lecture 10: Introduction to subpixel averaging <https://www.flexcompute.com/fdtd101/Lecture-10-Introduction-to-subpixel-averaging/>`_

--- a/docs/source/inversedesign.rst
+++ b/docs/source/inversedesign.rst
@@ -1,0 +1,11 @@
+***************************
+Inverse design in photonics
+***************************
+
+Adjoint optimization is a powerful tool that has gained significant attention in the photonics community. It leverages the adjoint method, a mathematical technique used to calculate gradients or derivatives of performance metrics with respect to design parameters. This method is particularly useful in photonics, where devices often have a large number of design parameters and complex performance metrics. This course is designed to provide a comprehensive understanding of the principles and applications of adjoint optimization in the field of photonics. 
+
+`Lecture 1: Introduction to Inverse Design In Photonics <https://www.flexcompute.com/fdtd101/Lecture-11-Introduction-to-Inverse-Design-In-Photonics/>`_
+
+`Lecture 2: Adjoint Method <https://www.flexcompute.com/fdtd101/Lecture-12-Inverse-Design-in-Photonics-Lecture-2-Adjoint-Method/>`_
+
+More lectures coming soon!

--- a/docs/source/notebooks/FocusedApodGC.ipynb
+++ b/docs/source/notebooks/FocusedApodGC.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "markdown",
    "id": "d35563e3-20e1-49e6-a9f9-a0a800ff4cbf",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -25,7 +24,6 @@
    "execution_count": 1,
    "id": "85959919-a2e6-48b1-996b-bc0f695c0a64",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -171,7 +169,6 @@
    "execution_count": 4,
    "id": "6c614860-73d4-4a2a-83c0-f081093461ae",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -543,7 +540,6 @@
    "execution_count": 6,
    "id": "39db5fa4-71f0-4af0-85ad-7bb678e6ff9d",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -772,7 +768,7 @@
    "id": "352c883f",
    "metadata": {},
    "source": [
-    "Next, we will build and run the parameter sweep using [web.run_async]((../notebooks/ParameterScan.html)). Verbosity will be turned off to reduce the amount of output data."
+    "Next, we will build and run the [parameter sweep](https://www.flexcompute.com/tidy3d/examples/notebooks/ParameterScan/) using [web.run_async](../_autosummary/tidy3d.web.run_async.html). Verbosity will be turned off to reduce the amount of output data."
    ]
   },
   {
@@ -1274,7 +1270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.9"
   },
   "title": "How to design a focusing apodized grating coupler in Tidy3D"
  },


### PR DESCRIPTION
To address https://github.com/flexcompute/tidy3d/issues/946, a "lectures" section is added. Under this section, currently there are only FDTD101 and Inverse design lectures (on-going). I assume we will have more in the future. What do you think @tylerflex ?