### PR TITLE
remove broken edit page button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,7 +165,7 @@ html_theme_options = {
         "binderhub_url": "https://mybinder.org/v2/gh/flexcompute-readthedocs/tidy3d-docs/readthedocs?labpath=docs%2Fsource%2Fnotebooks",
         "notebook_interface": "jupyterlab",
     },
-    "use_edit_page_button": True,
+    "use_edit_page_button": False,
     "use_issues_button": True,
     "use_repository_button": True,
     "use_download_button": True,


### PR DESCRIPTION
Fixes this issue: https://github.com/flexcompute/tidy3d/issues/1071 
seems not possible to have this work as expected without combining the docs and front end repos into one.