### PR TITLE
replace filter feature_size with proper radius

### DIFF
--- a/docs/source/notebooks/AdjointPlugin3InverseDesign.ipynb
+++ b/docs/source/notebooks/AdjointPlugin3InverseDesign.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "    values = jnp.array(eps_boxes).reshape((nx, ny, 1, 1))\n",
     "    \n",
-    "    conic_filter = ConicFilter(feature_size=0.15, design_region_dl=size_box_x)\n",
+    "    conic_filter = ConicFilter(radius=0.26, design_region_dl=size_box_x)\n",
     "    binary_projector = BinaryProjector(vmin=1.0, vmax=eps_wg, beta=10.0)\n",
     "    \n",
     "    values_01 = (values - 1) / (eps_wg - 1)\n",
@@ -1327,157 +1327,55 @@
      "text": [
       "step = 1\n",
       "\tJ = 3.8211e-02\n",
-      "\tgrad_norm = 6.2339e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 6.2339e-02\n",
       "step = 2\n",
       "\tJ = 9.1523e-03\n",
-      "\tgrad_norm = 2.1577e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.1577e-02\n",
       "step = 3\n",
       "\tJ = 1.7992e-02\n",
-      "\tgrad_norm = 1.9351e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 1.9351e-02\n",
       "step = 4\n",
       "\tJ = 1.0272e-01\n",
-      "\tgrad_norm = 3.4287e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 3.4287e-02\n",
       "step = 5\n",
       "\tJ = 2.1192e-01\n",
-      "\tgrad_norm = 2.7697e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.7697e-02\n",
       "step = 6\n",
       "\tJ = 2.8863e-01\n",
-      "\tgrad_norm = 3.2258e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 3.2258e-02\n",
       "step = 7\n",
       "\tJ = 3.8170e-01\n",
-      "\tgrad_norm = 2.3159e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.3159e-02\n",
       "step = 8\n",
       "\tJ = 4.2126e-01\n",
-      "\tgrad_norm = 2.4545e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.4545e-02\n",
       "step = 9\n",
       "\tJ = 4.4030e-01\n",
-      "\tgrad_norm = 2.4022e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.4022e-02\n",
       "step = 10\n",
       "\tJ = 4.6227e-01\n",
-      "\tgrad_norm = 2.0112e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 2.0112e-02\n",
       "step = 11\n",
       "\tJ = 4.8933e-01\n",
-      "\tgrad_norm = 1.6016e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 1.6016e-02\n",
       "step = 12\n",
       "\tJ = 5.1567e-01\n",
-      "\tgrad_norm = 1.2213e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 1.2213e-02\n",
       "step = 13\n",
       "\tJ = 5.3551e-01\n",
-      "\tgrad_norm = 9.9448e-03\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 9.9448e-03\n",
       "step = 14\n",
       "\tJ = 5.5010e-01\n",
-      "\tgrad_norm = 1.0149e-02\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 1.0149e-02\n",
       "step = 15\n",
       "\tJ = 5.6510e-01\n",
-      "\tgrad_norm = 9.9075e-03\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 9.9075e-03\n",
       "step = 16\n",
       "\tJ = 5.8005e-01\n",
-      "\tgrad_norm = 8.2932e-03\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 8.2932e-03\n",
       "step = 17\n",
       "\tJ = 5.9122e-01\n",
-      "\tgrad_norm = 9.4998e-03\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\tgrad_norm = 9.4998e-03\n",
       "step = 18\n",
       "\tJ = 6.0470e-01\n",
       "\tgrad_norm = 1.1275e-02\n"
@@ -2164,7 +2062,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.9"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/docs/source/notebooks/AdjointPlugin6GratingCoupler.ipynb
+++ b/docs/source/notebooks/AdjointPlugin6GratingCoupler.ipynb
@@ -410,7 +410,8 @@
     "        eps: np.ndarray\n",
     "            Permittivity vector.\n",
     "    \"\"\"\n",
-    "    conic_filter = ConicFilter(feature_size=feature_size, design_region_dl=dr_grid_size)\n",
+    "    filter_radius = np.sqrt(3) * feature_size\n",
+    "    conic_filter = ConicFilter(radius=filter_radius, design_region_dl=dr_grid_size)\n",
     "    binary_projector = BinaryProjector(vmin=eps_min, vmax=eps_max, eta=eta, beta=beta, strict_binarize=binarize)\n",
     "    \n",
     "    rho_dot = conic_filter.evaluate(design_param.reshape(nx, ny))\n",
@@ -1361,7 +1362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.9"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
This PR just makes the notebooks compatible with the changes in the front end with the `ConicFilter`, which accepts `radius` instead of `feature_size`. note that the `radius` needs to be `sqrt(3)` times larger than the previous `feature_size` to get the same effect due to how we define things (radius=radius of conic filter, feature_size=heuristic for how large the features actually turn out).

@momchil-flex Ideally we should merge this before doing notebook runs for 2.4