### PR TITLE
Quickstart landing page.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,13 +1,98 @@
 Tidy3D Documentation
 ====================
 
-Tidy3D is a software package for solving extremely large electrodynamics problems using the finite-difference time-domain (FDTD) method.
+.. To do items:
+.. * open simple example in colab with API saved as environment variable and `!pip install tidy3d` in the first line.
+.. * toggle between command line - notebook / python instructions in section 1
+Tidy3D is a software package for solving extremely large electrodynamics problems using the finite-difference time-domain (FDTD) method. It can be controlled through either an `open source python package <https://github.com/flexcompute/tidy3d>`_ or a `web-based graphical user interface <https://tidy3d.simulation.cloud>`_.
 
-This is the documentation for the python API, which is the main way to build simulation models, submit jobs, and analyze results of completed runs.
+.. `TODO: open example in colab <https://github.com/flexcompute/tidy3d>`_
+
+1. Set up Tidy3d
+~~~~~~~~~~~~~~~~
+
+Install the python library `tidy3d <https://github.com/flexcompute/tidy3d>`_ for creating, managing, and postprocessing simulations with
+
+.. code-block:: bash
+
+   pip install tidy3d
+
+Next, configure your tidy3d package with the API key from your account.
+
+`Get your free API key <https://tidy3d.simulation.cloud/account?tab=apikey>`_
+
+.. code-block:: bash
+
+   tidy3d configure
+
+And enter your API key when prompted.
+
+For more detailed installation instructions, see `this page <https://docs.flexcompute.com/projects/tidy3d/en/latest/quickstart.html>`_.
+
+2. Run a Simulation
+~~~~~~~~~~~~~~~~~~~
+
+Start running simulations with just a few lines of code. Run this sample code to simulate a 3D dielectric box in Tidy3D and plot the corresponding field pattern.
+
+.. code-block:: python
+
+   # import the tidy3d package and configure it with your API key
+   import tidy3d as td
+   import tidy3d.web as web
+
+   # set up global parameters of simulation ( speed of light / wavelength in micron )
+   freq0 = td.C_0 / 0.75
+
+   # create structure - a box centered at 0, 0, 0 with a size of 1.5 micron and permittivity of 2
+   square = td.Structure(
+       geometry=td.Box(center=(0, 0, 0), size=(1.5, 1.5, 1.5)), 
+       medium=td.Medium(permittivity=2.0)
+   )
+
+   # create source - A uniform current source with frequency freq0 on the left side of the domain
+   source = td.UniformCurrentSource(
+       center=(-1.5, 0, 0),
+       size=(0, 0.4, 0.4),
+       source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10.0),
+       polarization="Ey",
+   )
+
+   # create monitor - Measures electromagnetic fields within the entire domain at z=0
+   monitor = td.FieldMonitor(
+       size=(td.inf, td.inf, 0),
+       freqs=[freq0],
+       name="fields",
+       colocate=True,
+   )
+
+   # Initialize simulation - Combine all objects together into a single specification to run
+   sim = td.Simulation(
+       size=(4, 3, 3),
+       grid_spec=td.GridSpec.auto(min_steps_per_wvl=25),
+       structures=[square],
+       sources=[source],
+       monitors=[monitor],
+       run_time=120/freq0,
+   )
+
+   # run simulation through the cloud and plot the field data computed by the solver and stored in the monitor
+   data = td.web.run(sim, task_name="quickstart", path="data/data.hdf5", verbose=False)
+   ax = data.plot_field("fields", "Ey", z=0)
+
+
+3. Analyze Results
+~~~~~~~~~~~~~~~~~~
+
+a) Postprocess simulation data using the same python session, or
+
+b) View the results of this simulation on our web-based `graphical user interface <https://tidy3d.simulation.cloud>`_.
+
+4. Learn More
+~~~~~~~~~~~~~
 
 .. toctree::
    :maxdepth: 1
-   :caption: User Guide
+   :caption: Resources
 
    quickstart
    examples
@@ -17,5 +102,4 @@ This is the documentation for the python API, which is the main way to build sim
    changelog
    Tidy3D Solver Technology <https://www.flexcompute.com/tidy3d/solver/>
 
-.. image:: _static/ring_resonator.png
-   :width: 1200
+

--- a/docs/source/index_old.rst
+++ b/docs/source/index_old.rst
@@ -1,0 +1,21 @@
+Tidy3D Documentation
+====================
+
+Tidy3D is a software package for solving extremely large electrodynamics problems using the finite-difference time-domain (FDTD) method.
+
+This is the documentation for the python API, which is the main way to build simulation models, submit jobs, and analyze results of completed runs.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: User Guide
+
+   quickstart
+   examples
+   faq
+   howdoi
+   api
+   changelog
+   Tidy3D Solver Technology <https://www.flexcompute.com/tidy3d/solver/>
+
+.. image:: _static/ring_resonator.png
+   :width: 1200


### PR DESCRIPTION
This PR adds a streamlined "Quickstart" to our docs landing page (index.rst), including
* What is Tidy3d?
* How to install tidy3d (for most people)
* A minimal simulation code snippet to copy and paste.
* Information about how to post process or view post-run results in GUI
* Various Relevant links throughout the text and listed at the bottom.

Some things we could do to make this better:
* Toggle between `command line` and `python` instructions for installation and configure.
* (possibly?) Toggle between `linux / mac` and `windows` instructions
* Add link to colab notebook with the minimal example and API key loaded as environment variable.
* Make the font better, add emojis, generally make the docs look nicer.

Will put the last section of bullets in its own front end issue for tracking.

Build viewable here https://docs.flexcompute.com/projects/tidy3d/en/tyler-revamp-index/

<img width="671" alt="image" src="https://github.com/flexcompute-readthedocs/tidy3d-docs/assets/92756888/b152c168-6418-4dd9-a681-ce9f4a9be9b1">

<img width="672" alt="image" src="https://github.com/flexcompute-readthedocs/tidy3d-docs/assets/92756888/b30903df-5657-4cf4-bf4e-231579b54967">
