### PR TITLE
Doc reorg to include Tidy3D Python tutorials in the learning center

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -25,7 +25,7 @@ Feature Tutorials
 -------------------
 
 Mediums
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -37,7 +37,7 @@ Mediums
     notebooks/CustomMediumTutorial
 
 Structures
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -49,7 +49,7 @@ Structures
     notebooks/PhotonicCrystalsComponents
 
 Grid Specification
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -57,7 +57,7 @@ Grid Specification
     notebooks/AutoGrid
 
 Boundary Conditions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -65,7 +65,7 @@ Boundary Conditions
     notebooks/BoundaryConditions
 
 Sources
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -76,7 +76,7 @@ Sources
     notebooks/CustomFieldSource
 
 Monitors and Data Visualization
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -87,7 +87,7 @@ Monitors and Data Visualization
     notebooks/FieldProjections  
 
 Mode Solver
-~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -96,7 +96,7 @@ Mode Solver
     notebooks/WaveguidePluginDemonstration
 
 Parameter Sweep
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
@@ -104,7 +104,7 @@ Parameter Sweep
     notebooks/ParameterScan
 
 Scattering Matrix
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -75,8 +75,8 @@ Sources
     notebooks/TFSF
     notebooks/CustomFieldSource
 
-Monitors and Data Visualization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Data Visualization and Postprocessing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -19,11 +19,24 @@ Tidy3D Basics
     notebooks/StartHere
     notebooks/Simulation
     notebooks/Primer
+    notebooks/WebAPI
 
 Feature Tutorials
 -------------------
 
-Structures and Materials
+Mediums
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    notebooks/Dispersion
+    notebooks/Fitting
+    notebooks/FullyAnisotropic
+    notebooks/Gyrotropic
+    notebooks/CustomMediumTutorial
+
+Structures
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
@@ -31,23 +44,27 @@ Structures and Materials
 
     notebooks/GDSImport
     notebooks/STLImport
-    notebooks/Dispersion
-    notebooks/Fitting
-    notebooks/FullyAnisotropic
-    notebooks/Gyrotropic
-    notebooks/CustomMediumTutorial
     notebooks/SelfIntersectingPolyslab
+    notebooks/PICComponents
+    notebooks/PhotonicCrystalsComponents
 
-Grid and Boundary Conditions
+Grid Specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    notebooks/AutoGrid
+
+Boundary Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
 
     notebooks/BoundaryConditions
-    notebooks/AutoGrid
 
-Sources and Monitors
+Sources
 ~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
@@ -58,26 +75,18 @@ Sources and Monitors
     notebooks/TFSF
     notebooks/CustomFieldSource
 
-Running Simulations
-~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-    :maxdepth: 1
-
-    notebooks/WebAPI
-    notebooks/ParameterScan
-
-Visualization of Simulation and Monitor Data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monitors and Data Visualization
+~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
 
     notebooks/VizSimulation
     notebooks/VizData
-    notebooks/AnimationTutorial
+    notebooks/AnimationTutorial  
+    notebooks/FieldProjections  
 
-Utility Tools
+Mode Solver
 ~~~~~~~~~~~~~
 
 .. toctree::
@@ -85,10 +94,22 @@ Utility Tools
 
     notebooks/ModeSolver
     notebooks/WaveguidePluginDemonstration
-    notebooks/FieldProjections
+
+Parameter Sweep
+~~~~~~~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    notebooks/ParameterScan
+
+Scattering Matrix
+~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
     notebooks/SMatrix
-    notebooks/PICComponents
-    notebooks/PhotonicCrystalsComponents
 
 FDTD Adjoint Optimization
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/inversedesign.rst
+++ b/docs/source/inversedesign.rst
@@ -10,4 +10,6 @@ Adjoint optimization is a powerful tool that has gained significant attention in
 
 `Lecture 3: Adjoint Optimization <https://www.flexcompute.com/tidy3d/learning-center/inverse-design/Inverse-Design-in-Photonics-Lecture-3-Adjoint-Optimization/>`_
 
+`Lecture 4: Fabrication Constraints <https://www.flexcompute.com/tidy3d/learning-center/inverse-design/Inverse-Design-in-Photonics-Lecture-4-Fabrication-Constraints/>`_
+
 More lectures coming soon!

--- a/docs/source/inversedesign.rst
+++ b/docs/source/inversedesign.rst
@@ -4,8 +4,10 @@ Inverse design in photonics
 
 Adjoint optimization is a powerful tool that has gained significant attention in the photonics community. It leverages the adjoint method, a mathematical technique used to calculate gradients or derivatives of performance metrics with respect to design parameters. This method is particularly useful in photonics, where devices often have a large number of design parameters and complex performance metrics. This course is designed to provide a comprehensive understanding of the principles and applications of adjoint optimization in the field of photonics. 
 
-`Lecture 1: Introduction to Inverse Design In Photonics <https://www.flexcompute.com/fdtd101/Lecture-11-Introduction-to-Inverse-Design-In-Photonics/>`_
+`Lecture 1: Introduction to Inverse Design In Photonics <https://www.flexcompute.com/tidy3d/learning-center/inverse-design/Lecture-1-Introduction-to-Inverse-Design-In-Photonics/>`_
 
-`Lecture 2: Adjoint Method <https://www.flexcompute.com/fdtd101/Lecture-12-Inverse-Design-in-Photonics-Lecture-2-Adjoint-Method/>`_
+`Lecture 2: Adjoint Method <https://www.flexcompute.com/tidy3d/learning-center/inverse-design/Lecture-2-Inverse-Design-in-Photonics-Lecture-2-Adjoint-Method/>`_
+
+`Lecture 3: Adjoint Optimization <https://www.flexcompute.com/tidy3d/learning-center/inverse-design/Inverse-Design-in-Photonics-Lecture-3-Adjoint-Optimization/>`_
 
 More lectures coming soon!


### PR DESCRIPTION
We will include those introductory Python notebooks (from basics to adjoint) on learning center. I've proposed this reorganization to have a more uniform categorization on both Tidy3D Python and Tidy3D GUI tutorials.