### PR TITLE
SCEM-3114: Python plot_3d() layout auto adjustment and full-screen mode

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -9,3 +9,4 @@
 body { line-height: 1.42857143; }
 p {margin-bottom: 0.5rem}
 .heading-style, h1, h2, h3, h4, h5, h6 {margin: 1.6rem 0 1rem;}
+iframe {width: 100%;border: unset}

--- a/docs/source/notebooks/VizSimulation.ipynb
+++ b/docs/source/notebooks/VizSimulation.ipynb
@@ -720,7 +720,7 @@
      "data": {
       "text/html": [
        "\n",
-       "    <iframe id=\"simulation-viewer168562516275455536\" src=https://feature-simulation-viewer.d3a9gfg7glllfq.amplifyapp.com/simulation-viewer?uuid=168562516275455536 width=\"800\" height=\"800\"></iframe>\n",
+       "    <iframe id=\"simulation-viewer168562516275455536\" src=https://feature-simulation-viewer.d3a9gfg7glllfq.amplifyapp.com/simulation-viewer?uuid=168562516275455536 width=\"800\" height=\"800\" allowfullscreen=\"true\"></iframe>\n",
        "    <script>\n",
        "        \n",
        "    window.postMessageToViewer168562516275455536 = event => {\n",


### PR DESCRIPTION
please refer to [https://flow360.atlassian.net/browse/SCEM-3114](https://flow360.atlassian.net/browse/SCEM-3114)
you can visit this link to verify. [https://docs.flexcompute.com/projects/tidy3d/en/feature-mktg-246/](https://docs.flexcompute.com/projects/tidy3d/en/feature-mktg-246/)

The scope of this update includes:

1. Remove the border of the iframe and Auto-adjust the width of the 3D chart to fit inside the containing box
2. add "allowfullscreen" attribute to iframe
