### PR TITLE
Adding two-photon absorption and others to api.rst

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -160,8 +160,11 @@ Nonlinear
 .. autosummary::
    :toctree: _autosummary/
     
-    NonlinearSpec
-    NonlinearSusceptibility
+   NonlinearSpec
+   NonlinearModel
+   NonlinearSusceptibility
+   KerrNonlinearity
+   TwoPhotonAbsorption
 
 Material Library
 ----------------
@@ -208,7 +211,8 @@ Source Time Dependence
    :toctree: _autosummary/
 
    GaussianPulse
-   .. ContinuousWave
+   ContinuousWave
+   CustomSourceTime
 
 
 Monitors


### PR DESCRIPTION
This adds the following to api.rst:

NonlinearModel
TwoPhotonAbsorption
KerrNonlinearity
ContinuousWave
CustomSourceTime