### PR TITLE
Fixed broken links in notebooks

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -176,6 +176,30 @@ Time Modulation
    ContinuousWaveTimeModulation
    SpaceModulation
 
+Medium Perturbations
+--------------------
+
+Mediums with Heat and Charge Perturbation Models
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   PerturbationMedium
+   PerturbationPoleResidue
+
+Perturbation Specifications of Individual Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   ParameterPerturbation
+   LinearHeatPerturbation
+   CustomHeatPerturbation
+   LinearChargePerturbation
+   CustomChargePerturbation
+
 Material Library
 ----------------
 

--- a/docs/source/notebooks/AdjointPlugin10YBranchLevelSet.ipynb
+++ b/docs/source/notebooks/AdjointPlugin10YBranchLevelSet.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "> **Note: the cost of running the entire notebook is higher than 1 FlexCredit.**\n",
     "\n",
-    "This notebook demonstrates how to set up and run a parameterized level set-based optimization of a Y-branch. In this approach, we use `jax` to generate a level set surface $\\phi(\\rho)$ given a set of control knots $\\rho$. The permittivity distribution is then obtained implicitly from the zero level set isocontour. Details about the level set method can be found [here](https://doi.org/10.1016/S0045-7825(02)00559-5). Minimum gap and curvature penalty terms are introduced in the optimization to control the minimum feature size, hence improving device fabrication. In addition, we show how to tailor the initial level set function to a starting geometry, which is helpful to further optimize a device obtained by conventional design.\n",
+    "This notebook demonstrates how to set up and run a parameterized level set-based optimization of a Y-branch. In this approach, we use `jax` to generate a level set surface $\\phi(\\rho)$ given a set of control knots $\\rho$. The permittivity distribution is then obtained implicitly from the zero level set isocontour. Details about the level set method can be found [here](<https://doi.org/10.1016/S0045-7825(02)00559-5>). Minimum gap and curvature penalty terms are introduced in the optimization to control the minimum feature size, hence improving device fabrication. In addition, we show how to tailor the initial level set function to a starting geometry, which is helpful to further optimize a device obtained by conventional design.\n",
     "\n",
     "You can also find some interesting adjoint functionalities for shape optimization in [Inverse design optimization of a waveguide taper](https://www.flexcompute.com/tidy3d/examples/notebooks/AdjointPlugin5BoundaryGradients/) and [Adjoint-based shape optimization of a waveguide bend](https://www.flexcompute.com/tidy3d/examples/notebooks/AdjointPlugin8WaveguideBend/). If you are new to the finite-difference time-domain (FDTD) method, we highly recommend going through our [FDTD101](https://www.flexcompute.com/tidy3d/learning-center/fdtd101/) tutorials. FDTD simulations can diverge due to various reasons. If you run into any simulation divergence issues, please follow the steps outlined in our [troubleshooting guide](https://www.flexcompute.com/tidy3d/examples/notebooks/DivergedFDTDSimulation/) to resolve it.\n",
     "\n",
@@ -2195,7 +2195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.9"
   },
   "title": "How to perform the inverse design of a y-branch using level set and the adjoint plugin in Tidy3D FDTD"
  },

--- a/docs/source/notebooks/HeatSolver.ipynb
+++ b/docs/source/notebooks/HeatSolver.ipynb
@@ -515,7 +515,7 @@
    "id": "199aac97-7b8c-4ca0-82eb-a5656cd9de96",
    "metadata": {},
    "source": [
-    "Plotting function of [HeatSimulation](../_autosummary/tidy3d.HeatSimulation.html) displays heat conductivity information of structures using gray scale colors, assigned boundary conditions using thick lines (orange for [TemperatureBC](../_autosummary/tidy3d.TemperatureBC.html), green for [HeatFlxBC](../_autosummary/tidy3d.HeatFlxBC.html), and brown for [ConvectionBC](../_autosummary/tidy3d.ConvectionBC.html)), and heat sources as colored dots. Specifying `colorbar=\"conductivity\"` or `colorbar=\"source\"` changes the colorbar accordingly."
+    "Plotting function of [HeatSimulation](../_autosummary/tidy3d.HeatSimulation.html) displays heat conductivity information of structures using gray scale colors, assigned boundary conditions using thick lines (orange for [TemperatureBC](../_autosummary/tidy3d.TemperatureBC.html), green for [HeatFluxBC](../_autosummary/tidy3d.HeatFluxBC.html), and brown for [ConvectionBC](../_autosummary/tidy3d.ConvectionBC.html)), and heat sources as colored dots. Specifying `colorbar=\"conductivity\"` or `colorbar=\"source\"` changes the colorbar accordingly."
    ]
   },
   {
@@ -1929,7 +1929,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/TimeModulationTutorial.ipynb
+++ b/docs/source/notebooks/TimeModulationTutorial.ipynb
@@ -13,7 +13,7 @@
    "id": "a3add6f0-739b-4452-9700-eb20e31b5b2c",
    "metadata": {},
    "source": [
-    "In active nanophotonic devices such as electro-optical modulators, materials can be modulated in both space and time. In `Tidy3D`, space-time modulations can be applied to a regular [Medium](../_autosummary/tidy3d.Medium.html), or a dispersive medium such as [Lorentz](../_autosummary/tidy3d.Lorentz.html), or even a spatially varying medium such as [CustomMedium](../_autosummary/tidy3d.CustoMedium.html).\n",
+    "In active nanophotonic devices such as electro-optical modulators, materials can be modulated in both space and time. In `Tidy3D`, space-time modulations can be applied to a regular [Medium](../_autosummary/tidy3d.Medium.html), or a dispersive medium such as [Lorentz](../_autosummary/tidy3d.Lorentz.html), or even a spatially varying medium such as [CustomMedium](../_autosummary/tidy3d.CustomMedium.html).\n",
     "\n",
     "In this tutorial, we illustrate how to define such a modulated material with [ModulationSpec](../_autosummary/tidy3d.ModulationSpec.html) that allows us to apply spatio-temporal modulations to permittivity and electric conductivity. Specifically, we consider transmission spectrum of a harmonically modulated dielectric slab, and show the generation of sidebands in the spectrum."
    ]
@@ -2332,7 +2332,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.9"
   },
   "title": "How to apply time modulation to materials in Tidy3D FDTD"
  },

--- a/docs/source/notebooks/WaveguideBendSimulator.ipynb
+++ b/docs/source/notebooks/WaveguideBendSimulator.ipynb
@@ -21,7 +21,7 @@
    "id": "a1c2d627",
    "metadata": {},
    "source": [
-    "`Tidy3D` offers a versatile web-based [graphical user interface](tidy3d.simulation.clouid) (GUI) suitable for a wide range of FDTD simulations from photonic integrated circuit components to metasurfaces and diffractive gratings. While this general-purpose GUI is beneficial for its extensive capabilities, there are situations where you might need to focus on simulating a specific device type repeatedly. For these scenarios, Tidy3D's [Python API](https://docs.flexcompute.com/projects/tidy3d/en/latest/api.html) paired with open-source Python libraries such as [tkinter](https://docs.python.org/3/library/tkinter.html) enables the easy creation of a customized GUI. This specialized interface, designed with fewer controls and buttons, streamlines the simulation process for ease of use. By sharing this bespoke GUI with less experienced colleagues, they can also efficiently run simulations without extensive prior knowledge or expertise in FDTD.\n",
+    "`Tidy3D` offers a versatile web-based [graphical user interface](tidy3d.simulation.cloud) (GUI) suitable for a wide range of FDTD simulations from photonic integrated circuit components to metasurfaces and diffractive gratings. While this general-purpose GUI is beneficial for its extensive capabilities, there are situations where you might need to focus on simulating a specific device type repeatedly. For these scenarios, Tidy3D's [Python API](https://docs.flexcompute.com/projects/tidy3d/en/latest/api.html) paired with open-source Python libraries such as [tkinter](https://docs.python.org/3/library/tkinter.html) enables the easy creation of a customized GUI. This specialized interface, designed with fewer controls and buttons, streamlines the simulation process for ease of use. By sharing this bespoke GUI with less experienced colleagues, they can also efficiently run simulations without extensive prior knowledge or expertise in FDTD.\n",
     "\n",
     "Here we demonstrate the creation of a simple GUI for 90-degree waveguide bend simulation. In this GUI, users can select materials for the waveguide bend, substrate, and cladding through combo boxes. We include common materials such as silicon, silicon nitride, silicon oxide, and so on. Users can also select between a circular bend and an Euler bend. Geometric parameters can be entered in the input boxes to define the waveguide dimensions and bend radius. Before running the simulation, users can view the simulation setup as well as the grid by clicking the \"View simulation\" button. Lastly, users can start the simulation by clicking the \"Run simulation\" button. After the simulation, the bending loss is automatically plotted. We also include a text window to display some relevant text outputs. \n",
     "\n",
@@ -205,7 +205,7 @@
    "id": "9f8be7e1",
    "metadata": {},
    "source": [
-    "We also create a helper function to convert the $x$ and $y$ coordinates of a path into a Tidy3D [Structure](../tidy3d.Structure.html) by utilizing [gdstk](https://heitzmann.github.io/gdstk/)."
+    "We also create a helper function to convert the $x$ and $y$ coordinates of a path into a Tidy3D [Structure](../_autosummary/tidy3d.Structure.html) by utilizing [gdstk](https://heitzmann.github.io/gdstk/)."
    ]
   },
   {
@@ -245,7 +245,7 @@
    "id": "853e2641",
    "metadata": {},
    "source": [
-    "Next we define a function to create a Tidy3D [Simulation](../_autosummary/tidy3d.Simulation.html) instance. In this function, we need to extract the values of the user inputs in the GUI, define the waveguide bend structure based on the extracted values, define a [ModeSource](/_autosummary/tidy3d.ModeSource.html) to excite the input waveguide and a [ModeMonitor](/_autosummary/tidy3d.ModeMonitor.html) to measure the transmission to the output waveguide, and lastly return a [Simulation](/_autosummary/tidy3d.Simulation.html)."
+    "Next we define a function to create a Tidy3D [Simulation](../_autosummary/tidy3d.Simulation.html) instance. In this function, we need to extract the values of the user inputs in the GUI, define the waveguide bend structure based on the extracted values, define a [ModeSource](../_autosummary/tidy3d.ModeSource.html) to excite the input waveguide and a [ModeMonitor](../_autosummary/tidy3d.ModeMonitor.html) to measure the transmission to the output waveguide, and lastly return a [Simulation](../_autosummary/tidy3d.Simulation.html)."
    ]
   },
   {
@@ -576,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.9"
   },
   "title": "Waveguide Bend Simulator | Flexcompute"
  },


### PR DESCRIPTION
This PR fixes a few broken links found by Shuang [here](https://flow360.atlassian.net/browse/MKTG-314). 

Broken links in the ThermallyTunedRingResonator notebook and the MetalHeaterPhaseShifter notebook are due to API references not built. @dbochkov-flexcompute will fix the API references then the links should be fine.